### PR TITLE
Fix for recent iOS 11 JBs

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ As an aside, the following directions assume the target device has already been 
 
 Upload keychain_dumper to a directory of your choice on the target device (I have used /tmp during testing).  Also, once uploaded, be sure to validate that keychain_dumper is executable (chmod +x ./keychain_dumper if it isn't) and validate that /private/var/Keychains/keychain-2.db is world readable (chmod +r /private/var/Keychains/keychain-2.db if it isn't).
 
+Note: iOS 11 devices using Electra (or other jailbreaks) may still require a trick to bypass the native sandbox. Compile the binary with the included _entitlements.xml_, sign it with the developer account certificate/priv_key and copy the binary to _/bin_ or _/sbin_ (which already allows execution).
+
 If you are using the binary from Git you can attempt to dump all of the accessible password Keychain entries by simply running the tool with now flags
 
     ./keychain_dumper

--- a/entitlements.xml
+++ b/entitlements.xml
@@ -6,5 +6,6 @@
 		<array>
 			<string>*</string>
 		</array>
+		<key>platform-application</key> <true/>
 	</dict>
 </plist>


### PR DESCRIPTION
Hey Patrick,
This is a small PR to fix issues on recent iOS JB devices. Electra (and others) are still kind of broken in term of entitlements. 

If you execute the current version, you will get:
```
# ./keychain_dumper
-sh: ./keychain_dumper: cannot execute binary file: Operation not permitted
```
iOS sandbox is kicking in. As a result, it's a necessary to adjust entitlements and run from a directory which is already allowed to contain executable.

_I haven't uploaded the actual binary since no one trusts random binaries from the Internet?_ :)