### PR TITLE
iOS 12 support

### DIFF
--- a/entitlements.xml
+++ b/entitlements.xml
@@ -7,5 +7,8 @@
 			<string>*</string>
 		</array>
 		<key>platform-application</key> <true/>
+
+		<key>com.apple.private.security.no-container</key>	<true/>
+
 	</dict>
 </plist>


### PR DESCRIPTION
Found I needed to add com.apple.private.security.no-container entitlement to avoid "Killed: 9" error. dmesg output was as below before I added the entitlement.

Using unc0ver jailbreak v3.0.0 b46 on iPhone 5s, iOS 12.1.1 b3

Sandbox: bash(1243) System Policy: deny(1) process-exec* /private/var/root/keychain_dumperSandbox: hook..execve() killing keychain_dumper[pid=1243, uid=0]: (err=1) process-exec denied while updating labe