### PR TITLE
Code cleanup and readme fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,25 +2,24 @@
 
 ## Usage
 
-All that should be needed to use keychain_dumper is the binary that is checked in to the Keychain-Dumper Git repository.  This binary has been signed with a self-signed certificate with a "wildcard" entitlement. The entitlement allowed keychain_dumperaccess to all Keychain items in older iOS released. That support seems to have been removed in more recent releases of iOS. Instead, you must now add explicit entitlements that exist on a given device (entitlements can be app-specific). To help with that, this repository includes a `updateEntitlements.sh` shell script that can be run on-device to grant `keychain_dumper` all of the entitlements available on the device. Finally, if you either don't trust this binary or are having trouble dumping Keychain items using the below steps, you may can build the tool from source and manually sign the appropriate entitlments into your build of the keychain_dumper binary.
+All that should be needed to use this tool is the binary that is in the [Releases tab](https://github.com/ptoomey3/Keychain-Dumper/releases/).  This binary has been signed with a self-signed certificate with a "wildcard" entitlement. This entitlement allows keychain_dumper access to all Keychain items in older iOS releases. That support seems to have been removed in more recent releases of iOS. Instead, you must now add explicit entitlements that exist on a given device (entitlements can be app-specific). To help with that, this repository includes a `updateEntitlements.sh` shell script that can be run on-device to grant `keychain_dumper` all of the entitlements available on the device. Finally, if you either don't trust the binary in the Releases tab or are having trouble dumping Keychain items using the below steps, you can build the tool from source and manually sign the appropriate entitlments into your build of the keychain_dumper binary.
 
-As an aside, the following directions assume the target device has already been jailbroken.
+To follow these directions successfully, your device must be jailbroken.
 
-Upload keychain_dumper to a directory of your choice on the target device (I have used /tmp during testing).  Also, once uploaded, be sure to validate that keychain_dumper is executable (chmod +x ./keychain_dumper if it isn't) and validate that /private/var/Keychains/keychain-2.db is world readable (chmod +r /private/var/Keychains/keychain-2.db if it isn't).
+Upload keychain_dumper to a directory of your choice on the target device (I have used /tmp during testing). Once uploaded, be sure to validate that keychain_dumper is executable (chmod +x ./keychain_dumper if it isn't) and validate that /private/var/Keychains/keychain-2.db is world readable (chmod +r /private/var/Keychains/keychain-2.db if it isn't).
 
-Note: iOS 11 devices using Electra (or other jailbreaks) may still require a trick to bypass the native sandbox. Compile the binary with the included _entitlements.xml_, sign it with the developer account certificate/priv_key and copy the binary to _/bin_ or _/sbin_ (which already allows execution).
+Note: iOS 11 devices using Electra (or other jailbreaks) may still require a trick to bypass the native sandbox. Compile the binary with the included `entitlements.xml`, sign it with the developer account certificate/priv_key and copy the binary to `/bin` or `/sbin` (which already allow execution).
 
-If you are using the binary from Git you can attempt to dump all of the accessible password Keychain entries by simply running the tool with now flags
+If you are using the binary from the Releases tab you can attempt to dump all of the accessible password Keychain entries by simply running the tool with no flags:
+```bash
+    # ./keychain_dumper
+```
+Some Keychain entries are available regardless of whether the device is locked or not, while other entries will only be accessible if the iOS device is unlocked (i.e. a user has entered their pin). If your device has Touch ID or Face ID enabled, a prompt will appear asking for the appropriate identification. If no Keychain entries are displayed, or if you don't trust the provided binary, you may need to rerun the tool after building the application from source.  Please see the Build section below for details on how to build and sign the application.
 
-    ./keychain_dumper
-
-Some keychain entries are available regardless of whether the iOS is locked or not, while other entries will only be accessible if the iOS device is unlocked (i.e. a user has entered their pin).  If no Keychain entries are displayed, or if you don't want to trust the provided binary, you may need to rerun the tool after building the application from source.  Please see the Build section below for details on how to build and sign the application.
-
-By default keychain_dumper only dumps "Generic" and "Internet" passwords.  This is generally what you are interested in, as most application passwords are stored as "Generic" or "Internet" passwords.  However, you can also pass optional flags to dump additional information from the Keychain.  If you run keychain_dumper with the `-h` option you will get the following usage string:
+By default, keychain_dumper only dumps _Generic_ and _Internet_ passwords.  This is generally what you are most interested in, as most application passwords are stored as _Generic_ or _Internet_ passwords.  However, you can also pass optional flags to dump additional information from the Keychain.  If you run keychain_dumper with the `-h` option you will get the following usage string:
 
     Usage: keychain_dumper [-e]|[-h]|[-agnick]
     <no flags>: Dump Password Keychain Items (Generic Password, Internet Passwords)
-    -s: Dump All Keychain Items of a selected entitlement group
     -a: Dump All Keychain Items (Generic Passwords, Internet Passwords, Identities, Certificates, and Keys)
     -e: Dump Entitlements
     -g: Dump Generic Passwords
@@ -28,41 +27,44 @@ By default keychain_dumper only dumps "Generic" and "Internet" passwords.  This 
     -i: Dump Identities
     -c: Dump Certificates
     -k: Dump Keys
+	-s: Dump Selected Entitlement Group
 
-By default passing no option flags is equivalent to running keychain_dumper with the `-gn` flags set.  The other flags largely allow you to dump additional information related to certificates that are installed on the device.
+By default, passing no flags is equivalent to running keychain_dumper with the `-gn` flags set.  The other flags largely allow you to dump additional information related to certificates that are installed on the device.
 
 ## Building
 
 ### Create a Self-Signed Certificate
 
-Open up the Keychain Access app located in /Applications/Utilties/Keychain Access
+This section requires a Mac.
+
+Open up the Keychain Access app located in `/Applications/Utilties/Keychain Access` (In the _Other_ folder in Launchpad).
 
 From the application menu open Keychain Access -> Certificate Assistant -> Create a Certificate
 
-Enter a name for the certificate, and make note of it, as you will need it later when you sign `keychain_dumper`.  Make sure the Identity Type is “Self Signed Root” and the Certificate Type is “Code Signing”.  You don’t need to check the “Let me override defaults” unless you want to change other properties on the certificate (name, email, etc).
+Enter a name for the certificate, and make note of it, as you will need it later when you sign `keychain_dumper`.  Make sure the Identity Type is “Self Signed Root” and the Certificate Type is “Code Signing”.  You don’t need to check “Let me override defaults” unless you want to change other properties on the certificate (name, email, etc).
 
 ### Build It
 
-You should be able to compile the project using the included makefile.
+You should be able to compile the project using the included Makefile.
 
-    make
+    $ make
 
-If all goes well you should have a binary `keychain_dumper` placed in the same directory as all of the other project files.
+If all goes well you should have a binary `keychain_dumper` placed in the same directory as the cloned repository.
 
 ### Sign It
 
 First we need to find the certificate to use for signing.
 
-    make list
+    $ make list
 
 Find the 40 character hex string corresponding to the certificate you generated above. You can then sign `keychain_dumper`.
 
-    CER=<40 character hex string for certificate> make codesign
+    $ CER=(40 character hex string for certificate) make codesign
 
-You should now be able to follow the directions specified in the Usage section above.  If you don't want to use the wildcard entitlment file that is provided (or you are runnig more modern versions of iOS that don't support a wildcafrd entitlement), you can also sign specific entitlements into the binary.  Using the unsigned Keychain Dumper you can get a list of entitelments that exist on your specific iOS device by using the `-e` flag.  For example, you can run Keychain Dumper as follows:
-
-    ./keychain_dumper -e > /var/tmp/entitlements.xml
-
+You should now be able to follow the directions specified in the Usage section above.  If you don't want to use the wildcard entitlment file that is provided (or you are running more modern versions of iOS that don't support a wildcard entitlement), you can also sign specific entitlements into the binary.  Using an unsigned keychain_dumper binary, you can get a list of entitelments that exist on your specific iOS device with the `-e` flag.  For example:
+```bash
+    # ./keychain_dumper -e > /var/tmp/entitlements.xml
+```
 The resulting file can be used in place of the included entitlements.xml file.
 
 ## Contact & Help

--- a/main.m
+++ b/main.m
@@ -8,13 +8,13 @@
  * are permitted provided that the following conditions are met:
  *
  *  - Redistributions of source code must retain the above copyright notice, this list
- *    of conditions and the following disclaimer.
+ *	of conditions and the following disclaimer.
  *  - Redistributions in binary form must reproduce the above copyright notice, this
- *    list of conditions and the following disclaimer in the documentation and/or
- *    other materials provided with the distribution.
+ *	list of conditions and the following disclaimer in the documentation and/or
+ *	other materials provided with the distribution.
  *  - Neither the name of Neohapsis nor the names of its contributors may be used to
- *    endorse or promote products derived from this software without specific prior
- *    written permission.
+ *	endorse or promote products derived from this software without specific prior
+ *	written permission.
  *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
@@ -35,14 +35,14 @@
 #import "sqlite3.h"
 #include "stdio.h"
 
-#define KNRM  "\x1B[0m"
-#define KRED  "\x1B[31m"
-#define KGRN  "\x1B[32m"
-#define KYEL  "\x1B[33m"
-#define KBLU  "\x1B[34m"
-#define KMAG  "\x1B[35m"
-#define KCYN  "\x1B[36m"
-#define KWHT  "\x1B[37m"
+#define KNRM "\x1B[0m"
+#define KRED "\x1B[31m"
+#define KGRN "\x1B[32m"
+#define KYEL "\x1B[33m"
+#define KBLU "\x1B[34m"
+#define KMAG "\x1B[35m"
+#define KCYN "\x1B[36m"
+#define KWHT "\x1B[37m"
 
 static NSString *selectedEntitlementConstant = @"none";
 static NSString *databasePath = @"/var/Keychains/keychain-2.db";
@@ -50,26 +50,30 @@ static NSString *databasePath = @"/var/Keychains/keychain-2.db";
 
 void printToStdOut(NSString *format, ...)
 {
-    va_list args;
-    va_start(args, format);
-    NSString *formattedString = [[NSString alloc] initWithFormat: format arguments: args];
-    va_end(args);
-    [[NSFileHandle fileHandleWithStandardOutput] writeData: [formattedString dataUsingEncoding: NSUTF8StringEncoding]];
+	va_list args;
+	va_start(args, format);
+	NSString *formattedString = [[NSString alloc] initWithFormat: format arguments: args];
+	va_end(args);
+	[[NSFileHandle fileHandleWithStandardOutput] writeData: [formattedString dataUsingEncoding: NSUTF8StringEncoding]];
 	[formattedString release];
 }
 
 /// Prints a `NSData` to stdout, with either the format "\(name): \(data)\n\n" if the data is valid UTF-8, or "\(name) (Hex): \(data)\n\n" if it isn't
-void printDataToStdOut(const char *name, NSData *data) {
+void printDataToStdOut(const char *name, NSData *data)
+{
 	NSString *utf8Str = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
-	if (utf8Str) {
+	if (utf8Str)
+	{
 		printToStdOut(@"%s: %@\n\n", name, utf8Str);
 		[utf8Str release];
 	}
-	else {
+	else 
+	{
 		NSUInteger length = [data length];
 		char *hexStr = malloc(length * 2 + 1);
 		const uint8_t *ptr = [data bytes];
-		for (int i = 0; i < length; i++) {
+		for (int i = 0; i < length; i++)
+		{
 			sprintf(hexStr + i*2, "%02x", ptr[i]);
 		}
 		printToStdOut(@"%s (Hex): 0x%s\n\n", name, hexStr);
@@ -79,27 +83,27 @@ void printDataToStdOut(const char *name, NSData *data) {
 
 NSString *runProcess(NSString *executablePath, NSArray *args)
 {
-    NSPipe *pipe = [NSPipe pipe];
-    NSFileHandle *file = pipe.fileHandleForReading;
+	NSPipe *pipe = [NSPipe pipe];
+	NSFileHandle *file = pipe.fileHandleForReading;
 
-    NSTask *task = [[NSTask alloc] init];
-    task.launchPath = executablePath;
-    task.arguments = args;
-    task.standardOutput = pipe;
-    task.standardError = [NSPipe pipe];
-    [task launch];
+	NSTask *task = [[NSTask alloc] init];
+	task.launchPath = executablePath;
+	task.arguments = args;
+	task.standardOutput = pipe;
+	task.standardError = [NSPipe pipe];
+	[task launch];
 
-    NSData *data = [file readDataToEndOfFile];
-    [file closeFile];
+	NSData *data = [file readDataToEndOfFile];
+	[file closeFile];
 
-    return [[NSString alloc] initWithData: data encoding: NSUTF8StringEncoding];
+	return [[NSString alloc] initWithData: data encoding: NSUTF8StringEncoding];
 }
 
 NSString *saveDataTemporarily(NSData *data)
 {
-    NSString *tmpPath = @"/tmp/data";
-    [data writeToFile:tmpPath atomically:YES];
-    return tmpPath;
+	NSString *tmpPath = @"/tmp/data";
+	[data writeToFile:tmpPath atomically:YES];
+	return tmpPath;
 }
 
 NSString *runOpenSSLWithArgs(NSArray *args)
@@ -110,45 +114,43 @@ NSString *runOpenSSLWithArgs(NSArray *args)
 	{
 		return runProcess(@"/usr/bin/openssl", args);
 	}
-    else
-    {
-    	printToStdOut(@"%s[ERROR] Cannot dump certificates, please install \"openssl\" with Cydia.\n%s",KRED, KWHT);
-    	exit(0);
-    }
+	else
+	{
+		printToStdOut(@"%s[ERROR] Cannot dump certificates, please install \"openssl\" with Cydia.\n%s",KRED, KWHT);
+		exit(0);
+	}
 }
 
 NSString *runOpenSSLForConversion(NSString *prog, NSData *data)
 {
-    NSArray *args =  @[prog, @"-inform", @"der", @"-in", saveDataTemporarily(data), @"-outform", @"pem"];
-    return runOpenSSLWithArgs(args);
+	NSArray *args =  @[prog, @"-inform", @"der", @"-in", saveDataTemporarily(data), @"-outform", @"pem"];
+	return runOpenSSLWithArgs(args);
 }
 
 NSString *runOpenSSLForPublicConversion(NSString *prog, NSData *data)
 {
-    NSArray *args =  @[prog, @"-RSAPublicKey_in", @"-inform", @"der", @"-in", saveDataTemporarily(data), @"-outform", @"pem"];
-    return runOpenSSLWithArgs(args);
+	NSArray *args =  @[prog, @"-RSAPublicKey_in", @"-inform", @"der", @"-in", saveDataTemporarily(data), @"-outform", @"pem"];
+	return runOpenSSLWithArgs(args);
 }
 
 void printPrivateKeyPEM(NSData *data)
 {
-    printToStdOut(@"%@\n", runOpenSSLForConversion(@"rsa", data));
+	printToStdOut(@"%@\n", runOpenSSLForConversion(@"rsa", data));
 }
 
 void printPublicKeyPEM(NSData *data)
 {
-    printToStdOut(@"%@\n", runOpenSSLForPublicConversion(@"rsa", data));
+	printToStdOut(@"%@\n", runOpenSSLForPublicConversion(@"rsa", data));
 }
 
 void printCertPEM(NSData *data)
 {
-    printToStdOut(@"%@\n", runOpenSSLForConversion(@"x509", data));
+	printToStdOut(@"%@\n", runOpenSSLForConversion(@"x509", data));
 }
-
-
 
 void printUsage()
 {
-    printToStdOut(@"Usage: keychain_dumper [-e]|[-h]|[-agnick]\n");
+	printToStdOut(@"Usage: keychain_dumper [-e]|[-h]|[-agnick]\n");
 	printToStdOut(@"<no flags>: Dump Password Keychain Items (Generic Password, Internet Passwords)\n");
 	printToStdOut(@"-a: Dump All Keychain Items (Generic Passwords, Internet Passwords, Identities, Certificates, and Keys)\n");
 	printToStdOut(@"-e: Dump Entitlements\n");
@@ -162,38 +164,38 @@ void printUsage()
 
 void dumpKeychainEntitlements()
 {
-    const char *dbpath = [databasePath UTF8String];
-    sqlite3 *keychainDB;
-    sqlite3_stmt *statement;
+	const char *dbpath = [databasePath UTF8String];
+	sqlite3 *keychainDB;
+	sqlite3_stmt *statement;
 	NSMutableString *entitlementXML = [NSMutableString stringWithString:@"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
-                                       "<!DOCTYPE plist PUBLIC \"-//Apple//DTD PLIST 1.0//EN\" \"http://www.apple.com/DTDs/PropertyList-1.0.dtd\">\n"
-                                       "<plist version=\"1.0\">\n"
-                                       "\t<dict>\n"
-                                       "\t\t<key>keychain-access-groups</key>\n"
-                                       "\t\t<array>\n"];
-    if (sqlite3_open(dbpath, &keychainDB) == SQLITE_OK)
-    {
-        const char *query_stmt = "select distinct agrp from genp union select distinct agrp from inet union select distinct agrp from cert union select distinct agrp from keys;";
+									   "<!DOCTYPE plist PUBLIC \"-//Apple//DTD PLIST 1.0//EN\" \"http://www.apple.com/DTDs/PropertyList-1.0.dtd\">\n"
+									   "<plist version=\"1.0\">\n"
+									   "\t<dict>\n"
+									   "\t\t<key>keychain-access-groups</key>\n"
+									   "\t\t<array>\n"];
+	if (sqlite3_open(dbpath, &keychainDB) == SQLITE_OK)
+	{
+		const char *query_stmt = "select distinct agrp from genp union select distinct agrp from inet union select distinct agrp from cert union select distinct agrp from keys;";
 
-        if (sqlite3_prepare_v2(keychainDB, query_stmt, -1, &statement, NULL) == SQLITE_OK)
-        {
-            while(sqlite3_step(statement) == SQLITE_ROW)
-            {
+		if (sqlite3_prepare_v2(keychainDB, query_stmt, -1, &statement, NULL) == SQLITE_OK)
+		{
+			while(sqlite3_step(statement) == SQLITE_ROW)
+			{
 				NSString *group = [[NSString alloc] initWithUTF8String:(const char *) sqlite3_column_text(statement, 0)];
 
-                [entitlementXML appendFormat:@"\t\t\t<string>%@</string>\n", group];
-                [group release];
-            }
-            sqlite3_finalize(statement);
-        }
-        else
-        {
-            printToStdOut(@"Unknown error querying keychain database\n");
+				[entitlementXML appendFormat:@"\t\t\t<string>%@</string>\n", group];
+				[group release];
+			}
+			sqlite3_finalize(statement);
+		}
+		else
+		{
+			printToStdOut(@"Unknown error querying keychain database\n");
 		}
 
-        [entitlementXML appendString:@"\t\t</array>\n"
-         "\t</dict>\n"
-         "</plist>\n"];
+		[entitlementXML appendString:@"\t\t</array>\n"
+		 "\t</dict>\n"
+		 "</plist>\n"];
 		sqlite3_close(keychainDB);
 		printToStdOut(@"%@", entitlementXML);
 	}
@@ -206,30 +208,30 @@ void dumpKeychainEntitlements()
 NSString *listEntitlements()
 {
 	NSMutableArray *entitlementsArray = [[NSMutableArray alloc] init];
-    const char *dbpath = [databasePath UTF8String];
-    sqlite3 *keychainDB;
-    sqlite3_stmt *statement;
-    if (sqlite3_open(dbpath, &keychainDB) == SQLITE_OK)
-    {
-        const char *query_all = "select distinct agrp from genp union select distinct agrp from inet union select distinct agrp from cert union select distinct agrp from keys;";
-        if (sqlite3_prepare_v2(keychainDB, query_all, -1, &statement, NULL) == SQLITE_OK)
-        {
-        	printToStdOut(@"%s[INFO] Listing available Entitlement Groups:\n%s", KGRN, KWHT);
-        	int index = 0;
-            while(sqlite3_step(statement) == SQLITE_ROW)
-            {
+	const char *dbpath = [databasePath UTF8String];
+	sqlite3 *keychainDB;
+	sqlite3_stmt *statement;
+	if (sqlite3_open(dbpath, &keychainDB) == SQLITE_OK)
+	{
+		const char *query_all = "select distinct agrp from genp union select distinct agrp from inet union select distinct agrp from cert union select distinct agrp from keys;";
+		if (sqlite3_prepare_v2(keychainDB, query_all, -1, &statement, NULL) == SQLITE_OK)
+		{
+			printToStdOut(@"%s[INFO] Listing available Entitlement Groups:\n%s", KGRN, KWHT);
+			int index = 0;
+			while(sqlite3_step(statement) == SQLITE_ROW)
+			{
 				NSString *group = [[NSString alloc] initWithUTF8String:(const char *) sqlite3_column_text(statement, 0)];
-                printToStdOut(@"Entitlement Group [%i]: %@\n",index, group);
-                [entitlementsArray addObject:group];
-                [group release];
-                index += 1;
-            }
-            sqlite3_finalize(statement);
-        }
-        else
-        {
-            printToStdOut(@"%s[ERROR] Unknown error querying keychain database\n%s", KRED, KWHT);
-            return @"none";
+				printToStdOut(@"Entitlement Group [%i]: %@\n",index, group);
+				[entitlementsArray addObject:group];
+				[group release];
+				index += 1;
+			}
+			sqlite3_finalize(statement);
+		}
+		else
+		{
+			printToStdOut(@"%s[ERROR] Unknown error querying keychain database\n%s", KRED, KWHT);
+			return @"none";
 		}
 
 		sqlite3_close(keychainDB);
@@ -254,19 +256,19 @@ NSString *listEntitlements()
 
 NSMutableArray *getCommandLineOptions(int argc, char **argv)
 {
-    NSMutableArray *arguments = [[NSMutableArray alloc] init];
+	NSMutableArray *arguments = [[NSMutableArray alloc] init];
 	int argument;
 	if (argc == 1)
-    {
-        [arguments addObject:(id)kSecClassGenericPassword];
+	{
+		[arguments addObject:(id)kSecClassGenericPassword];
 		[arguments addObject:(id)kSecClassInternetPassword];
 		return [arguments autorelease];
 	}
-	while ((argument = getopt (argc, argv, "aegnickhs")) != -1)
-    {
-        switch(argument)
-        {
-        	case 's':
+	while ((argument = getopt(argc, argv, "aegnickhs")) != -1)
+	{
+		switch(argument)
+		{
+			case 's':
 				selectedEntitlementConstant = listEntitlements();
 				[arguments addObject:(id)kSecClassGenericPassword];
 				[arguments addObject:(id)kSecClassInternetPassword];
@@ -274,8 +276,8 @@ NSMutableArray *getCommandLineOptions(int argc, char **argv)
 				[arguments addObject:(id)kSecClassCertificate];
 				[arguments addObject:(id)kSecClassKey];
 				return [arguments autorelease];
-            case 'a':
-                [arguments addObject:(id)kSecClassGenericPassword];
+			case 'a':
+				[arguments addObject:(id)kSecClassGenericPassword];
 				[arguments addObject:(id)kSecClassInternetPassword];
 				[arguments addObject:(id)kSecClassIdentity];
 				[arguments addObject:(id)kSecClassCertificate];
@@ -303,7 +305,7 @@ NSMutableArray *getCommandLineOptions(int argc, char **argv)
 				printUsage();
 				break;
 			case '?':
-			    printUsage();
+				printUsage();
 			 	exit(EXIT_FAILURE);
 			default:
 				continue;
@@ -312,9 +314,9 @@ NSMutableArray *getCommandLineOptions(int argc, char **argv)
 	return [arguments autorelease];
 }
 
-NSArray * getKeychainObjectsForSecClass(CFTypeRef kSecClassType)
+NSArray *getKeychainObjectsForSecClass(CFTypeRef kSecClassType)
 {
-    NSMutableDictionary *genericQuery = [[NSMutableDictionary alloc] init];
+	NSMutableDictionary *genericQuery = [[NSMutableDictionary alloc] init];
 	[genericQuery setObject:(id)kSecClassType forKey:(id)kSecClass];
 	[genericQuery setObject:(id)kSecMatchLimitAll forKey:(id)kSecMatchLimit];
 	[genericQuery setObject:(id)kCFBooleanTrue forKey:(id)kSecReturnAttributes];
@@ -329,30 +331,30 @@ NSArray * getKeychainObjectsForSecClass(CFTypeRef kSecClassType)
 	return keychainItems;
 }
 
-NSString * getEmptyKeychainItemString(CFTypeRef kSecClassType)
+NSString *getEmptyKeychainItemString(CFTypeRef kSecClassType)
 {
 	if (kSecClassType == kSecClassGenericPassword)
-    {
+	{
 		return @"[INFO] No Generic Password Keychain items found.\n[HINT] You should unlock your device!\n";
 	}
 	else if (kSecClassType == kSecClassInternetPassword)
-    {
+	{
 		return @"[INFO] No Internet Password Keychain items found.\n[HINT] You should unlock your device!\n";
 	}
 	else if (kSecClassType == kSecClassIdentity)
-    {
+	{
 		return @"[INFO] No Identity Keychain items found.\n[HINT] You should unlock your device!\n";
 	}
 	else if (kSecClassType == kSecClassCertificate)
-    {
+	{
 		return @"[INFO] No Certificate Keychain items found.\n[HINT] You should unlock your device!\n";
 	}
 	else if (kSecClassType == kSecClassKey)
-    {
+	{
 		return @"[INFO] No Key Keychain items found.\n[HINT] You should unlock your device!\n";
 	}
 	else
-    {
+	{
 		return @"[INFO] Unknown Security Class\n[HINT] You should unlock your device!\n";
 	}
 }
@@ -360,26 +362,42 @@ NSString * getEmptyKeychainItemString(CFTypeRef kSecClassType)
 void printAccessibleAttribute(NSString *accessibleString)
 {
 	if ([accessibleString isEqualToString:@"dk"])
+	{
 		printToStdOut(@"%sAccessible Attribute: kSecAttrAccessibleAlways, protection level 0\n%s", KRED, KWHT);
+	}
 	else if ([accessibleString isEqualToString:@"ak"])
+	{
 		printToStdOut(@"%sAccessible Attribute: kSecAttrAccessibleWhenUnlocked, protection level 2 (default)\n%s", KYEL, KWHT);
+	}
 	else if ([accessibleString isEqualToString:@"ck"])
+	{
 		printToStdOut(@"%sAccessible Attribute: kSecAttrAccessibleAfterFirstUnlock, protection level 1\n%s", KRED, KWHT);
+	}
 	else if ([accessibleString isEqualToString:@"dku"])
+	{
 		printToStdOut(@"%sAccessible Attribute: kSecAttrAccessibleAlwaysThisDeviceOnly, protection level 3\n%s", KBLU, KWHT);
+	}
 	else if ([accessibleString isEqualToString:@"aku"])
+	{
 		printToStdOut(@"%sAccessible Attribute: kSecAttrAccessibleWhenUnlockedThisDeviceOnly, protection level 5\n%s", KBLU, KWHT);
+	}
 	else if ([accessibleString isEqualToString:@"cku"])
+	{
 		printToStdOut(@"%sAccessible Attribute: kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly, protection level 4\n%s", KBLU, KWHT);
+	}
 	else if ([accessibleString isEqualToString:@"akpu"])
+	{
 		printToStdOut(@"%sAccessible Attribute: kSecAttrAccessibleWhenPasscodeSetThisDeviceOnly, protection level 6\n%s",KGRN, KWHT);
+	}
 	else
+	{
 		printToStdOut(@"%sUnknown Accessible Attribute: %@\n%s", KRED, accessibleString, KWHT);
+	}
 }
 
 void printGenericPassword(NSDictionary *passwordItem)
 {
-    printToStdOut(@"Generic Password\n");
+	printToStdOut(@"Generic Password\n");
 	printToStdOut(@"----------------\n");
 	printToStdOut(@"Service: %@\n", [passwordItem objectForKey:(id)kSecAttrService]);
 	printToStdOut(@"Account: %@\n", [passwordItem objectForKey:(id)kSecAttrAccount]);
@@ -397,7 +415,7 @@ void printGenericPassword(NSDictionary *passwordItem)
 
 void printInternetPassword(NSDictionary *passwordItem)
 {
-    printToStdOut(@"Internet Password\n");
+	printToStdOut(@"Internet Password\n");
 	printToStdOut(@"-----------------\n");
 	printToStdOut(@"Server: %@\n", [passwordItem objectForKey:(id)kSecAttrServer]);
 	printToStdOut(@"Account: %@\n", [passwordItem objectForKey:(id)kSecAttrAccount]);
@@ -411,7 +429,7 @@ void printInternetPassword(NSDictionary *passwordItem)
 
 void printCertificate(NSDictionary *certificateItem)
 {
-    SecCertificateRef certificate = (SecCertificateRef)[certificateItem objectForKey:(id)kSecValueRef];
+	SecCertificateRef certificate = (SecCertificateRef)[certificateItem objectForKey:(id)kSecValueRef];
 	CFStringRef summary;
 	summary = SecCertificateCopySubjectSummary(certificate);
 	printToStdOut(@"Certificate\n");
@@ -430,22 +448,22 @@ void printCertificate(NSDictionary *certificateItem)
 
 void printKey(NSDictionary *keyItem)
 {
-    NSString *keyClass = @"Unknown";
-    //NSLog(@"%@", keyItem); //Debugging purposes
+	NSString *keyClass = @"Unknown";
+	//NSLog(@"%@", keyItem); //Debugging purposes
 	CFTypeRef _keyClass = [keyItem objectForKey:(id)kSecAttrKeyClass];
 	CFTypeRef _keyType = [keyItem objectForKey:(id)kSecAttrKeyType];
 	int keySize = [[keyItem objectForKey:(id)kSecAttrKeySizeInBits] intValue];
 	int effectiveKeySize = [[keyItem objectForKey:(id)kSecAttrEffectiveKeySize] intValue];
 	if ([[(id)_keyClass description] isEqual:(id)kSecAttrKeyClassPublic])
-    {
+	{
 		keyClass = @"Public";
 	}
 	else if ([[(id)_keyClass description] isEqual:(id)kSecAttrKeyClassPrivate])
-    {
+	{
 		keyClass = @"Private";
 	}
 	else if ([[(id)_keyClass description] isEqual:(id)kSecAttrKeyClassSymmetric])
-    {
+	{
 		keyClass = @"Symmetric";
 	}
 	printToStdOut(@"Key\n");
@@ -508,81 +526,65 @@ void printIdentity(NSDictionary *identityItem)
 void printResultsForSecClass(NSArray *keychainItems, CFTypeRef kSecClassType)
 {
 	if (keychainItems == nil)
-    {
+	{
 		printToStdOut(getEmptyKeychainItemString(kSecClassType));
 		return;
 	}
-	NSDictionary *keychainItem;
-	for (keychainItem in keychainItems)
-    {
+	for (NSDictionary *keychainItem in keychainItems)
+	{
 		if (kSecClassType == kSecClassGenericPassword)
-        {
-        	if ([selectedEntitlementConstant isEqualToString:@"none"])
-     		{
-     			printGenericPassword(keychainItem);
-     		}
-			else
+		{
+			if ([selectedEntitlementConstant isEqualToString:@"none"])
+	 		{
+	 			printGenericPassword(keychainItem);
+	 		}
+			else if ([[keychainItem objectForKey:(id)kSecAttrAccessGroup] isEqualToString:selectedEntitlementConstant])
 			{
-				if ([[keychainItem objectForKey:(id)kSecAttrAccessGroup] isEqualToString:selectedEntitlementConstant])
-				{
-					printGenericPassword(keychainItem);
-				}
+				printGenericPassword(keychainItem);
 			}
 		}
 		else if (kSecClassType == kSecClassInternetPassword)
-        {
-        	if ([selectedEntitlementConstant isEqualToString:@"none"])
-     		{
-     			printInternetPassword(keychainItem);
-     		}
-			else
+		{
+			if ([selectedEntitlementConstant isEqualToString:@"none"])
+	 		{
+	 			printInternetPassword(keychainItem);
+	 		}
+			else if ([[keychainItem objectForKey:(id)kSecAttrAccessGroup] isEqualToString:selectedEntitlementConstant])
 			{
-				if ([[keychainItem objectForKey:(id)kSecAttrAccessGroup] isEqualToString:selectedEntitlementConstant])
-				{
-					printInternetPassword(keychainItem);
-				}
+				printInternetPassword(keychainItem);
 			}
 		}
 		else if (kSecClassType == kSecClassIdentity)
-        {
-            if ([selectedEntitlementConstant isEqualToString:@"none"])
-     		{
-     			printIdentity(keychainItem);
-     		}
-			else
+		{
+			if ([selectedEntitlementConstant isEqualToString:@"none"])
+	 		{
+	 			printIdentity(keychainItem);
+	 		}
+			else if ([[keychainItem objectForKey:(id)kSecAttrAccessGroup] isEqualToString:selectedEntitlementConstant])
 			{
-				if ([[keychainItem objectForKey:(id)kSecAttrAccessGroup] isEqualToString:selectedEntitlementConstant])
-				{
-					printIdentity(keychainItem);
-				}
+				printIdentity(keychainItem);
 			}
 		}
 		else if (kSecClassType == kSecClassCertificate)
-        {
+		{
 			if ([selectedEntitlementConstant isEqualToString:@"none"])
-     		{
-     			printCertificate(keychainItem);
-     		}
-			else
+	 		{
+	 			printCertificate(keychainItem);
+	 		}
+			else if ([[keychainItem objectForKey:(id)kSecAttrAccessGroup] isEqualToString:selectedEntitlementConstant])
 			{
-				if ([[keychainItem objectForKey:(id)kSecAttrAccessGroup] isEqualToString:selectedEntitlementConstant])
-				{
-					printCertificate(keychainItem);
-				}
+				printCertificate(keychainItem);
 			}
 		}
 		else if (kSecClassType == kSecClassKey)
-        {
+		{
 			if ([selectedEntitlementConstant isEqualToString:@"none"])
-     		{
-     			printKey(keychainItem);
-     		}
-			else
+	 		{
+	 			printKey(keychainItem);
+	 		}
+			else if ([[keychainItem objectForKey:(id)kSecAttrAccessGroup] isEqualToString:selectedEntitlementConstant])
 			{
-				if ([[keychainItem objectForKey:(id)kSecAttrAccessGroup] isEqualToString:selectedEntitlementConstant])
-				{
-					printKey(keychainItem);
-				}
+				printKey(keychainItem);
 			}
 		}
 	}
@@ -596,13 +598,13 @@ int main(int argc, char **argv)
 	arguments = getCommandLineOptions(argc, argv);
 	NSArray *passwordItems;
 	if ([arguments indexOfObject:@"dumpEntitlements"] != NSNotFound)
-    {
+	{
 		dumpKeychainEntitlements();
 		exit(EXIT_SUCCESS);
 	}
 	NSArray *keychainItems = nil;
 	for (id kSecClassType in (NSArray *) arguments)
-    {
+	{
 		keychainItems = getKeychainObjectsForSecClass((CFTypeRef)kSecClassType);
 		printResultsForSecClass(keychainItems, (CFTypeRef)kSecClassType);
 		[keychainItems release];


### PR DESCRIPTION
Changed all instances of 4 space tabs to proper tabs for consistency and so that all indentations are rendered the same by the GitHub file viewer.
You can see an example of this issue [here, in main.m @ line 230](https://github.com/ptoomey3/Keychain-Dumper/blob/51f7412a8f83e44edbd68a98ea434be922a1587e/main.m#L230). Line 230 and 233 look the same in Notepad++, but GitHub's editor has different lengths for a proper tab and 4 spaces, which results in the weird-looking formatting there.
Also, there was some inconsistency with using same-line opening braces or new-line opening braces, and the second one seemed more common so I gave all same-line braces their own line.

Updated the readme to include more recent or more accurate information, and fixed typos if I came across them.

Love this project, its helped me lots and I really appreciate it. Wanted to give something back to the project :smile: