### PR TITLE
Add SecAttrAccessControl printing functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,11 @@ You should be able to compile the project using the included makefile.
 
 If all goes well you should have a binary `keychain_dumper` placed in the same directory as all of the other project files.
 
+If you are not able to compile with default Apple SDK, try to replace SDK path in Makefile with Theos SDK:
+
+    SDK="/path/to/theos/sdks/iPhoneOS14.5.sdk"
+
+
 ### Sign It
 
 First we need to find the certificate to use for signing.
@@ -64,6 +69,23 @@ You should now be able to follow the directions specified in the Usage section a
     ./keychain_dumper -e > /var/tmp/entitlements.xml
 
 The resulting file can be used in place of the included entitlements.xml file.
+
+Large amount of access groups in entitlements.xml may result in tool not dumping any keys. Include only access groups that you want to dump keys from. Example of correct entitlements.xml file:
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>keychain-access-groups</key>
+    <array>
+      <string>groupName</string>
+    </array>
+    <key>platform-application</key> <true/>
+    <key>com.apple.private.security.no-container</key>  <true/>
+  </dict>
+</plist>
+```
 
 ## Contact & Help
 

--- a/main.m
+++ b/main.m
@@ -340,6 +340,19 @@ void printAccessibleAttribute(NSString *accessibleString) {
   }
 }
 
+void printSecAccessControl(NSObject *accessControlObject){
+  NSString* accessControlString = accessControlObject.debugDescription;
+  if ([accessControlString rangeOfString:@"pbioc"].location != NSNotFound && [accessControlString rangeOfString:@"pbioh"].location != NSNotFound) {
+    printToStdOut(@"%sSecAccessControl flag: .biometryCurrentSet%s\n", KGRN, KWHT);
+  }else if ([accessControlString rangeOfString:@"pbioc"].location != NSNotFound && [accessControlString rangeOfString:@"pbioh"].location == NSNotFound) {
+    printToStdOut(@"%sSecAccessControl flag: .biometryAny%s\n", KYEL, KWHT);
+  }else if ([accessControlString rangeOfString:@"cpo(DeviceOwnerAuthentication)"].location != NSNotFound) {
+    printToStdOut(@"%sSecAccessControl flag: .userPresence%s\n", KRED, KWHT);
+  }else if ([accessControlString rangeOfString:@"cup(true));odel(true)"].location != NSNotFound) {
+    printToStdOut(@"%sSecAccessControl flag: .devicePasscode%s\n", KRED, KWHT);
+  };
+}
+
 void printGenericPassword(NSDictionary *passwordItem) {
   printToStdOut(@"Generic Password\n");
   printToStdOut(@"----------------\n");
@@ -366,6 +379,7 @@ void printInternetPassword(NSDictionary *passwordItem) {
   printToStdOut(@"Label: %@\n", [passwordItem objectForKey:(id)kSecAttrLabel]);
   NSString* accessibleString = [passwordItem objectForKey:(id)kSecAttrAccessible];
   printAccessibleAttribute(accessibleString);
+  printSecAccessControl([passwordItem objectForKey:(id)kSecAttrAccessControl]);
   NSData* passwordData = [passwordItem objectForKey:(id)kSecValueData];
   printDataToStdOut("Keychain Data", passwordData);
 }
@@ -382,6 +396,7 @@ void printCertificate(NSDictionary *certificateItem) {
   printToStdOut(@"Label: %@\n", [certificateItem objectForKey:(id)kSecAttrLabel]);
   NSString* accessibleString = [certificateItem objectForKey:(id)kSecAttrAccessible];
   printAccessibleAttribute(accessibleString);
+  printSecAccessControl([certificateItem objectForKey:(id)kSecAttrAccessControl]);
   printToStdOut(@"Serial Number: %@\n", [certificateItem objectForKey:(id)kSecAttrSerialNumber]);
   printToStdOut(@"Subject Key ID: %@\n", [certificateItem objectForKey:(id)kSecAttrSubjectKeyID]);
   printToStdOut(@"Subject Key Hash: %@\n\n", [certificateItem objectForKey:(id)kSecAttrPublicKeyHash]);
@@ -408,6 +423,7 @@ void printKey(NSDictionary *keyItem) {
   printToStdOut(@"Label: %@\n", [keyItem objectForKey:(id)kSecAttrLabel]);
   NSString* accessibleString = [keyItem objectForKey:(id)kSecAttrAccessible];
   printAccessibleAttribute(accessibleString);
+  printSecAccessControl([keyItem objectForKey:(id)kSecAttrAccessControl]);
   printToStdOut(@"Application Label: %@\n", [keyItem objectForKey:(id)kSecAttrApplicationLabel]);
   printToStdOut(@"Application Tag: %@\n", [keyItem objectForKey:(id)kSecAttrApplicationTag]);
   printToStdOut(@"Key Class: %@\n", keyClass);


### PR DESCRIPTION
Hi, 

Adding functionality to quickly check SecAccessControl flags. This allows checking whether key requires password, biometry to be set or whether it should only respect current biometry settings and remove key when biometry settings were changed.